### PR TITLE
make sheet and time processing more robust

### DIFF
--- a/helpers/google_services.py
+++ b/helpers/google_services.py
@@ -246,11 +246,7 @@ class SheetsOperations:
         Initialize copied template timesheet with formatting,
         names, range protection, etc.
         """
-        ind_sheet = (
-            self.sheet.get(spreadsheetId=self.volunteer_timesheet_id)
-            .execute()
-            .get("sheets")[0]
-        )
+        ind_sheet = self._get_first_sheet()
 
         sheet_id = ind_sheet.get("properties").get("sheetId")
         protected_range_id = ind_sheet.get("protectedRanges")
@@ -271,6 +267,14 @@ class SheetsOperations:
             protected_range_id,
         )
 
+    def _get_first_sheet(self) -> dict:
+        """Get the metadata dict of the first sheet in the volunteer's timesheet."""
+        return (
+            self.sheet.get(spreadsheetId=self.volunteer_timesheet_id)
+            .execute()
+            .get("sheets")[0]
+        )
+
     def get_last_entry_datetime(
         self, clock_in: bool = True
     ) -> datetime.datetime | None:
@@ -279,11 +283,17 @@ class SheetsOperations:
         date_index = 0
         time_index = 1 if clock_in else 2
 
+        sheet_name = (
+            self._get_first_sheet()
+            .get("properties", {})
+            .get("title", "Sheet1")
+        )
+
         log_entries = (
             self.sheet.values()
             .get(
                 spreadsheetId=self.volunteer_timesheet_id,
-                range="Sheet1!A3:C",  # Columns are A: Date, B: Clock-in time, C: Clock-out time
+                range=f"'{sheet_name}'!A3:C",  # Columns are A: Date, B: Clock-in time, C: Clock-out time
                 majorDimension="ROWS",
                 dateTimeRenderOption="FORMATTED_STRING",
             )
@@ -308,9 +318,14 @@ class SheetsOperations:
         else:
             time_part = time_part[time_index]
 
-        return datetime.datetime.strptime(
-            f"{date_part} {time_part}", "%m/%d/%Y %I:%M %p"
-        )
+        time_formats = ["%m/%d/%Y %I:%M %p", "%m/%d/%Y %H:%M:%S", "%m/%d/%Y %I:%M:%S %p"]
+        for fmt in time_formats:
+            try:
+                return datetime.datetime.strptime(f"{date_part} {time_part}", fmt)
+            except ValueError:
+                continue
+
+        raise ValueError(f"Unable to parse time '{date_part}' '{time_part}'")
 
     def add_clock_in_entry_to_timesheet(self, log_entry: tuple, master=False):
         """

--- a/tests/get_last_entry_datetime_test.py
+++ b/tests/get_last_entry_datetime_test.py
@@ -1,0 +1,53 @@
+# pylint: disable=missing-docstring
+import datetime
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# config.py is gitignored (holds real credentials); stub it so google_services can import
+sys.modules["config"] = MagicMock()
+
+from helpers.google_services import SheetsOperations
+
+
+def build_sheets_op(values, sheet="Sheet1"):
+    sheet_ops = SheetsOperations(MagicMock(), "Test", "123")
+    mock_sheet = MagicMock()
+    mock_sheet.get().execute.return_value = {
+        "sheets": [{"properties": {"title": sheet}}]
+    }
+    mock_sheet.values().get().execute.return_value = (
+        {"values": values} if values else {}
+    )
+    sheet_ops.sheet = mock_sheet
+    return sheet_ops, mock_sheet
+
+
+@pytest.mark.parametrize(
+    "time_in, clock_in, expected",
+    [
+        ("3:00 PM", True, datetime.datetime(2026, 3, 13, 15, 0)),
+        ("12:00 AM", True, datetime.datetime(2026, 3, 13, 0, 0)),
+        ("5:00 PM", False, datetime.datetime(2026, 3, 13, 17, 0)),
+        ("15:00:00", True, datetime.datetime(2026, 3, 13, 15, 0)),
+        ("3:00:00 PM", True, datetime.datetime(2026, 3, 13, 15, 0)),
+    ],
+)
+def test_time_formats(time_in, clock_in, expected):
+    sheet_ops, _ = build_sheets_op([["03/13/2026", time_in, "5:00 PM"]])
+    assert sheet_ops.get_last_entry_datetime(clock_in=clock_in) == expected
+
+
+def test_unparseable_time_raises():
+    sheet_ops, _ = build_sheets_op([["03/13/2026", "invalid", "5:00 PM"]])
+    with pytest.raises(ValueError, match="Unable to parse time '03/13/2026' 'invalid'"):
+        sheet_ops.get_last_entry_datetime(clock_in=True)
+
+
+def test_renamed_sheet():
+    sheet_ops, mock_sheet = build_sheets_op(
+        [["03/13/2026", "3:00 PM", "5:00 PM"]], sheet="ODV Log"
+    )
+    sheet_ops.get_last_entry_datetime()
+    assert mock_sheet.values().get.call_args.kwargs["range"] == "'ODV Log'!A3:C"


### PR DESCRIPTION
Take the first sheet regardless of the name, and allow any time format

I don't have the local creds to fully run the tests, so I added a new test that mocks the creds.
Sheet documentation: https://developers.google.com/workspace/sheets/api/reference/rest/v4/spreadsheets/sheets